### PR TITLE
fix edge case in which blank image is downloaded/file name change

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -32,7 +32,11 @@ $(document).ready(function() {
   var canvas = document.getElementById('logo');
   download.addEventListener('click', function(event) {
     download.href = canvas.toDataURL();
-    download.download = $('input').val() + ".png";
+    var val = $('input').val();
+    if (val === '') {
+      val = 'supreme';
+    }
+    download.download = val + "-supreme.png";
   }, false);
   overwrite();
   updateText('Supreme');


### PR DESCRIPTION
First of all, thanks for this tool - it was one of the top results for "Supreme Logo Generator" on Google.

I'm proposing a smallish change here: when a blank image is downloaded, "png.png" is the default filename - perhaps a more descriptive default would make for a better user experience. I also added `-supreme.png` suffix to the downloaded filename for the general case.

Let me know what you think,
Nathan

Image:
<img src="http://i.imgur.com/F2UFlof.png"/>